### PR TITLE
Choose output format based on the pandoc writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ block.  The input block is replaced by image appears before the code
 block, and the `diagram-haskell` class is replaced by the `haskell`
 class, so that pandoc can perform syntax highlighting as usual.
 
+`diagrams-pandoc` produces images in the `pdf` format when used with
+the `latex` and `beamer` writers of `pandoc` and produced `png` output
+otherwise.
+
 I have only tested with pandoc's markdown reader.  In particular, the
 rst reader does not attach classes to code blocks, only to Div elements.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ to be run as a
 [pandoc filter](http://johnmacfarlane.net/pandoc/scripting.html) as
 shown above.
 
+`diagrams-pandoc` evaluates the diagrams expression `example` by
+default. This can be modified by passing a command line argument.
+
 `diagrams-pandoc` is aware of two code block classes.  A block with
 the `diagram` class will be replaced by the resulting image---the code
 will not appear in the output.  A block with the `diagram-haskell`

--- a/src/Text/Pandoc/Diagrams.hs
+++ b/src/Text/Pandoc/Diagrams.hs
@@ -25,12 +25,19 @@ import           Text.Pandoc.Definition
 import Control.Applicative
 #endif
 
--- TODO choose output format based on pandoc target
-backendExt :: String
-backendExt = "png"
+backendExt :: String -> String
+backendExt "beamer" = "pdf"
+backendExt "latex" = "pdf"
+backendExt _ = "png"
+
+-- Return output type for a string
+findOutputType :: String -> OutputType
+findOutputType "beamer" = PDF
+findOutputType "latex" = PDF
+findOutputType _ = PNG
 
 data Opts = Opts {
-    _outFormat  :: String, -- ^ Not currently used
+    _outFormat  :: String,
     _outDir     :: FilePath,
     _expression :: String
     }
@@ -58,7 +65,7 @@ insertDiagrams _ block = return [block]
 -- Copied from https://github.com/diagrams/diagrams-doc/blob/master/doc/Xml2Html.hs
 -- With the CPP removed, thereby requiring Cairo
 -- TODO clean this up, move it into -builder somehow
--- | Compile the literate source code of a diagram to a .png file with
+-- | Compile the literate source code of a diagram to a .png/.pdf file with
 --   a file name given by a hash of the source code contents
 compileDiagram :: Opts -> String -> IO (Either String String)
 compileDiagram opts src = do
@@ -72,7 +79,11 @@ compileDiagram opts src = do
 
                 zero
 
-                (CairoOptions "default.png" (dims $ V2 500 200) PNG False)
+                (CairoOptions "default.png"
+                              (dims $ V2 500 200)
+                              (findOutputType $ _outFormat opts)
+                              False
+                )
 
                 & DB.snippets .~ [src]
                 & DB.imports  .~
@@ -118,7 +129,7 @@ compileDiagram opts src = do
       return $ Right (mkFile (DB.hashToHexStr hash))
 
  where
-  mkFile base = _outDir opts </> base <.> backendExt
+  mkFile base = _outDir opts </> base <.> (backendExt $ _outFormat opts)
   ensureDir dir = do
     b <- doesDirectoryExist dir
     when (not b) $ createDirectory dir


### PR DESCRIPTION
Hi,

I have modified the code to produce images in `pdf` format when using the latex/beamer writers and in `png` format otherwise. I would appreciate if you could review and merge this change.

regards,
Venkat 