### PR TITLE
Bump version bounds of some dependencies

### DIFF
--- a/diagrams-pandoc.cabal
+++ b/diagrams-pandoc.cabal
@@ -16,24 +16,24 @@ build-type:          Simple
 Bug-reports:         http://github.com/diagrams/diagrams-pandoc/issues
 Extra-source-files:  README.md, CHANGELOG.md
 cabal-version:       >=1.10
-Tested-with:         GHC ==8.2.2 || ==8.4.3 || ==8.6.5 || ==8.8.3 || ==8.10.1
+Tested-with:         GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7
 Source-repository head
   type:     git
   location: http://github.com/diagrams/diagrams-pandoc.git
 
 library
-  build-depends:       base >= 4.6 && < 4.15,
+  build-depends:       base >= 4.6 && < 4.18,
                        text >= 1.2 && < 1.3,
-                       pandoc-types >= 1.20 && < 1.21,
+                       pandoc-types >= 1.20 && < 1.23,
                        diagrams-lib >= 1.3 && < 1.5,
-                       linear >= 1.10 && < 1.21,
+                       linear >= 1.10 && < 1.23,
                        diagrams-builder >= 0.7 && < 0.9,
                        diagrams-cairo >= 1.3 && < 1.5,
                        directory >= 1.2 && < 1.4,
                        filepath >= 1.3 && < 1.5,
                        diagrams-svg >= 1.4 && < 1.5,
-                       diagrams-core >= 1.4 && < 1.5,
-                       hashable >= 1.2 && < 1.4,
+                       diagrams-core >= 1.4 && < 1.6,
+                       hashable >= 1.2 && < 1.5,
                        svg-builder >= 0.1 && < 0.2
   exposed-modules: Text.Pandoc.Diagrams
   default-language: Haskell2010
@@ -43,15 +43,15 @@ library
 executable diagrams-pandoc
   main-is:             src/Main.hs
   other-extensions:    CPP
-  build-depends:       base >= 4.6 && < 4.15,
+  build-depends:       base >= 4.6 && < 4.18,
                        text >= 1.2 && < 1.3,
-                       pandoc-types >= 1.20 && < 1.21,
+                       pandoc-types >= 1.20 && < 1.23,
                        diagrams-lib >= 1.3 && < 1.5,
-                       linear >= 1.10 && < 1.21,
+                       linear >= 1.10 && < 1.23,
                        diagrams-builder >= 0.7 && < 0.9,
                        diagrams-cairo >= 1.3 && < 1.5,
                        directory >= 1.2 && < 1.4,
                        filepath >= 1.3 && < 1.5,
                        diagrams-pandoc,
-                       optparse-applicative >= 0.11 && < 0.16
+                       optparse-applicative >= 0.11 && < 0.19
   default-language:    Haskell2010

--- a/diagrams-pandoc.cabal
+++ b/diagrams-pandoc.cabal
@@ -23,8 +23,8 @@ Source-repository head
 
 library
   build-depends:       base >= 4.6 && < 4.18,
-                       text >= 1.2 && < 1.3,
-                       pandoc-types >= 1.20 && < 1.23,
+                       text >= 1.2 && < 2.1,
+                       pandoc-types >= 1.20 && < 1.24,
                        diagrams-lib >= 1.3 && < 1.5,
                        linear >= 1.10 && < 1.23,
                        diagrams-builder >= 0.7 && < 0.9,
@@ -44,8 +44,8 @@ executable diagrams-pandoc
   main-is:             src/Main.hs
   other-extensions:    CPP
   build-depends:       base >= 4.6 && < 4.18,
-                       text >= 1.2 && < 1.3,
-                       pandoc-types >= 1.20 && < 1.23,
+                       text >= 1.2 && < 2.1,
+                       pandoc-types >= 1.20 && < 1.24,
                        diagrams-lib >= 1.3 && < 1.5,
                        linear >= 1.10 && < 1.23,
                        diagrams-builder >= 0.7 && < 0.9,


### PR DESCRIPTION
- Bump versions of base, pandoc-types, linear, diagrams-core, hashable, text and optparse-applicative
- Some tweaks to "Tested-with"
  - Drop GHC 8.2
  - Add GHC 9.0.2 and 9.2.7
  - Tweak minor versions to reflect the latest in each major version

I have tested with GHC 8.10.7, 9.0.2, 9.2.7 and 9.4.5 myself. I think it may also be beneficial to setup CI for this package as well, like the ones in other `diagrams` packages.